### PR TITLE
Remove unused dep minipass-pipeline

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1316,14 +1316,6 @@
         "yallist": "^4.0.0"
       }
     },
-    "minipass-pipeline": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.2.tgz",
-      "integrity": "sha512-3JS5A2DKhD2g0Gg8x3yamO0pj7YeKGwVlDS90pF++kxptwx/F+B//roxf9SqYil5tQo65bijy+dAuAFZmYOouA==",
-      "requires": {
-        "minipass": "^3.0.0"
-      }
-    },
     "minipass-sized": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/minipass-sized/-/minipass-sized-1.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
   },
   "dependencies": {
     "minipass": "^3.1.0",
-    "minipass-pipeline": "^1.2.2",
     "minipass-sized": "^1.0.3",
     "minizlib": "^2.0.0"
   },


### PR DESCRIPTION
# What / Why
The dependency minipass-pipeline doesn't seem to be used in the package so i removed it.

# Note
Few test fail before and after the modification on my computer (doesn't seem to be related).
