### PR TITLE
fix: do not allow back pressure to slow receiving data from the socket

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -205,7 +205,9 @@ const fetch = (url, opts) => {
       const body = new Minipass()
       // exceedingly rare that the stream would have an error,
       // but just in case we proxy it to the stream in use.
-      res.on('error', /* istanbul ignore next */ er => body.emit('error', er)).pipe(body)
+      res.on('error', /* istanbul ignore next */ er => body.emit('error', er))
+      res.on('data', (chunk) => body.write(chunk))
+      res.on('end', () => body.end())
 
       const responseOptions = {
         url: request.url,


### PR DESCRIPTION
The previous behavior here pipes the socket directly into an instance of minipass, which applies back pressure through the entire pipeline of streams all the way down to the filesystem. When the filesystem or cpu become slow, this increased back pressure slows the rate at which we consume data from the socket to the point that we end up with the socket getting into a state where we are no longer receiving data from it and I _believe_ it's closing on its own.

This change ignores the back pressure from the socket and instead forcibly writes all the data it receives directly to this first instance of minipass. Applying back pressure from there is safe since we've already consumed the data from the socket and no longer need to rely on it being open and actively sending us data.

This seems to resolve quite a few of our `cb() never called` errors in the npm cli