### PR TITLE
do not lose extra opts when input is an object

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -32,7 +32,9 @@ class Request extends Body {
       : input && input.href ? Url.parse(input.href)
       : Url.parse(`${input}`)
 
-    if (!isRequest(input))
+    if (isRequest(input))
+      init = { ...input[INTERNALS], ...init }
+    else if (!input || typeof input === 'string')
       input = {}
 
     const method = (init.method || input.method || 'GET').toUpperCase()
@@ -61,7 +63,6 @@ class Request extends Body {
     }
 
     const signal = 'signal' in init ? init.signal
-      : isRequest(input) ? input.signal
       : null
 
     if (signal !== null && signal !== undefined && !isAbortSignal(signal))

--- a/test/request.js
+++ b/test/request.js
@@ -62,6 +62,7 @@ t.test('should support wrapping Request instance', t => {
     follow: 1,
     body: form,
     signal,
+    rejectUnauthorized: false,
   })
   const r2 = new Request(r1, {
     follow: 2
@@ -76,6 +77,7 @@ t.test('should support wrapping Request instance', t => {
   t.equal(r2.follow, 2)
   t.equal(r1.counter, 0)
   t.equal(r2.counter, 0)
+  t.same(Request.getNodeRequestOptions(r1), Request.getNodeRequestOptions(r2))
   t.end()
 })
 


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->

in make-fetch-happen we construct a request object and then pass it as the only parameter to fetch, like

```js
const req = new fetch.Request(uri, opts)
return fetch(req)
```

the current behavior of this module will extract some properties from the request object, but not all, which causes things like the `rejectUnauthorized`, `ca`, `cert`, `key`, etc options to be dropped when the actual request is sent.

in addition, the current behavior is such that if `input` was an object, but that object doesn't contain an `href` property, we would drop the entire object in favor of an empty one.

the changes here will allow the above usage to work as intended, as well as being more intuitive when passing input as an object.

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->

Related to https://github.com/npm/cli/issues/1700