### PR TITLE
Made `rejectUnauthorized` depend on NODE_TLS_REJECT_UNAUTHORIZED

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -81,7 +81,7 @@ class Request extends Body {
       key,
       passphrase,
       pfx,
-      rejectUnauthorized = true,
+      rejectUnauthorized = process.env.NODE_TLS_REJECT_UNAUTHORIZED !== '0',
       secureOptions,
       secureProtocol,
       servername,

--- a/test/https-with-ca-option.js
+++ b/test/https-with-ca-option.js
@@ -7,7 +7,7 @@ const { resolve } = require('path')
 const fixtures = resolve(__dirname, 'fixtures/tls')
 const { readFileSync: read } = require('fs')
 
-const ca = read(`${fixtures}/minipass-ca.pem`)
+const ca = read(`${fixtures}/minipass-CA.pem`)
 const cert = read(`${fixtures}/localhost.crt`)
 const key = read(`${fixtures}/localhost.key`)
 const { createServer } = require('https')

--- a/test/request.js
+++ b/test/request.js
@@ -264,6 +264,24 @@ t.test('should support DataView as body', t => {
   return req.text().then(result => t.equal(result, 'a=1'))
 })
 
+t.test('should set rejectUnauthorized to true if NODE_TLS_REJECT_UNAUTHORIZED is not set', t => {
+  const tlsRejectBefore = process.env.NODE_TLS_REJECT_UNAUTHORIZED
+  process.env.NODE_TLS_REJECT_UNAUTHORIZED = null;
+  const req = new Request('http://a.b');
+  t.equal(Request.getNodeRequestOptions(req).rejectUnauthorized, true);
+  process.env.NODE_TLS_REJECT_UNAUTHORIZED = tlsRejectBefore;
+  t.end();
+})
+
+t.test('should set rejectUnauthorized to false if NODE_TLS_REJECT_UNAUTHORIZED is set to \'0\'', t => {
+  const tlsRejectBefore = process.env.NODE_TLS_REJECT_UNAUTHORIZED
+  process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+  const req = new Request('http://a.b');
+  t.equal(Request.getNodeRequestOptions(req).rejectUnauthorized, false);
+  process.env.NODE_TLS_REJECT_UNAUTHORIZED = tlsRejectBefore;
+  t.end();
+})
+
 t.test('get node request options', t => {
   t.match(Request.getNodeRequestOptions(new Request('http://a.b', {
     method: 'POST',


### PR DESCRIPTION
Setting `NODE_TLS_REJECT_UNAUTHORIZED` in node will disable the ssl certificate verification. Minipass-fetch is currently unaware of this option.

## References
Fixes #11
