### PR TITLE
fix: check for existence of unref before calling

### DIFF
--- a/lib/body.js
+++ b/lib/body.js
@@ -132,7 +132,7 @@ class Body {
 
     // do not keep the process open just for this timeout, even
     // though we expect it'll get cleared eventually.
-    if (resTimeout) {
+    if (resTimeout && resTimeout.unref) {
       resTimeout.unref()
     }
 

--- a/test/body.js
+++ b/test/body.js
@@ -231,6 +231,20 @@ t.test('json', async t => {
   })
 })
 
+t.test('handles environments where setTimeout does not have unref', async t => {
+  const originalSetTimeout = setTimeout
+  // simulate environments without unref()
+  global.setTimeout = (func, time) =>
+    Object.assign(originalSetTimeout(func, time), { unref: null })
+  t.teardown(() => global.setTimeout = originalSetTimeout)
+
+  t.doesNotThrow(async () => {
+    const b = new Body(new Blob('a=1'), { timeout: 100 })
+    await b.text()
+    t.end()
+  })
+})
+
 t.test('write to streams', async t => {
   const w = body => Body.writeToStream(
     new Minipass({ encoding: 'utf8' }),


### PR DESCRIPTION
Environments like Electron do not always expose the Node.js setTiemout, so there is no unref
function on resTimeout. So update the check to also check if the unref function exists

Ref: https://github.com/electron/electron/issues/21162
