### PR TITLE
fix: correctly handle error events that happen after response events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
         run: npm ci
 
       - name: Run Tap Tests
-        run: npm test
+        run: npm test ${{ matrix.node-version == '10.0.x' && '-- --no-coverage' || '' }}
 
       - name: List dependencies
         run: npm ls -a

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,29 +1,53 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - latest
 
 jobs:
   build:
     strategy:
-      matrix:
-        node-version: [10.x, 12.x, 14.x, 15.x]
-        os: [ubuntu-latest, macOS-latest]
       fail-fast: false
+      matrix:
+        node-version: [10.0.x, 10.x, 12.0.x, 12.x, 14.0.x, 14.x, 15.x, 16.x]
+        platform:
+        - os: ubuntu-latest
+          shell: bash
+        - os: macos-latest
+          shell: bash
+        - os: windows-latest
+          shell: bash
+        - os: windows-latest
+          shell: cmd
+        - os: windows-latest
+          shell: powershell
 
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.platform.os }}
+    defaults:
+      run:
+        shell: ${{ matrix.platform.shell }}
 
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v1.1.0
 
       - name: Use Nodejs ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
+          cache: npm
+
+      - name: Update npm
+        run: npm i --prefer-online -g npm@latest
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
-      # Run for all environments
       - name: Run Tap Tests
         run: npm test
+
+      - name: List dependencies
+        run: npm ls -a

--- a/lib/index.js
+++ b/lib/index.js
@@ -94,6 +94,19 @@ const fetch = (url, opts) => {
     }
 
     req.on('error', er => {
+      // if a 'response' event is emitted before the 'error' event, then by the
+      // time this handler is run it's too late to reject the Promise for the
+      // response. instead, we forward the error event to the response stream
+      // so that the error will surface to the user when they try to consume
+      // the body. this is done as a side effect of aborting the request except
+      // for in windows, where we must forward the event manually, otherwise
+      // there is no longer a ref'd socket attached to the request and the
+      // stream never ends so the event loop runs out of work and the process
+      // exits without warning.
+      // coverage skipped here due to the difficulty in testing
+      // istanbul ignore next
+      if (req.res)
+        req.res.emit('error', er)
       reject(new FetchError(`request to ${request.url} failed, reason: ${
         er.message}`, 'system', er))
       finalize()

--- a/lib/index.js
+++ b/lib/index.js
@@ -299,8 +299,16 @@ const fetch = (url, opts) => {
 
 
       // for br
-      if (codings == 'br' && typeof zlib.BrotliDecompress === 'function') {
-        const decoder = new zlib.BrotliDecompress()
+      if (codings == 'br') {
+        // ignoring coverage so tests don't have to fake support (or lack of) for brotli
+        // istanbul ignore next
+        try {
+          var decoder = new zlib.BrotliDecompress()
+        } catch (err) {
+          reject(err)
+          finalize()
+          return
+        }
         // exceedingly rare that the stream would have an error,
         // but just in case we proxy it to the stream in use.
         body.on('error', /* istanbul ignore next */ er => decoder.emit('error', er)).pipe(decoder)

--- a/test/fixtures/server.js
+++ b/test/fixtures/server.js
@@ -346,7 +346,11 @@ class TestServer {
     if (p === '/multipart') {
       res.statusCode = 200
       res.setHeader('Content-Type', 'application/json')
-      const parser = new Multipart(req.headers['content-type'])
+      // the path option passed to the Multipart constructor cannot be an
+      // absolute path in Windows, we set it here manually because the default
+      // provided by 'parsed' is an absolute path
+      // ref: https://github.com/chjj/parsed/issues/10
+      const parser = new Multipart(req.headers['content-type'], { path: './' })
       let body = ''
       parser.on('part', (field, part) => body += field + '=' + part)
       parser.on('end', () => res.end(JSON.stringify({

--- a/test/fixtures/server.js
+++ b/test/fixtures/server.js
@@ -83,17 +83,14 @@ class TestServer {
       new zlib.Deflate().end('hello world').concat().then(buf => res.end(buf))
     }
 
-    // TODO: add brotli support to minizlib
     if (p === '/brotli') {
-      if (typeof zlib.BrotliCompress !== 'function') {
-        res.status = 500
-        res.end('Not implemented\n')
-      } else {
-        res.statusCode = 200
-        res.setHeader('Content-Type', 'text/plain')
-        res.setHeader('Content-Encoding', 'br')
-        new zlib.BrotliCompress().end('hello world').concat().then(buf => res.end(buf))
-      }
+      res.statusCode = 200
+      res.setHeader('Content-Type', 'text/plain')
+      res.setHeader('Content-Encoding', 'br')
+      // pre-compressed 'hello world', in-lined here so tests will run when the
+      // client doesn't support brotli
+      const buf = Buffer.from([0x0b, 0x05, 0x80, 0x68, 0x65, 0x6c, 0x6c, 0x6f, 0x20, 0x77, 0x6f, 0x72, 0x6c, 0x64, 0x03])
+      res.end(buf)
     }
 
 

--- a/test/https-with-ca-option.js
+++ b/test/https-with-ca-option.js
@@ -7,7 +7,7 @@ const { resolve } = require('path')
 const fixtures = resolve(__dirname, 'fixtures/tls')
 const { readFileSync: read } = require('fs')
 
-const ca = read(`${fixtures}/minipass-ca.pem`)
+const ca = read(`${fixtures}/minipass-CA.pem`)
 const cert = read(`${fixtures}/localhost.crt`)
 const key = read(`${fixtures}/localhost.key`)
 const { createServer } = require('https')

--- a/test/index.js
+++ b/test/index.js
@@ -400,7 +400,9 @@ t.test('handle network-error response', t =>
 t.test('handle DNS-error response', t =>
   t.rejects(fetch('http://domain.invalid'), {
     name: 'FetchError',
-    code: 'ENOTFOUND',
+    // this error depends on the platform and dns server in use,
+    // but it should be one of these two codes
+    code: /^(ENOTFOUND|EAI_AGAIN)$/,
   }))
 
 t.test('reject invalid json response', t =>

--- a/test/index.js
+++ b/test/index.js
@@ -106,7 +106,7 @@ t.test('reject if protocol unsupported', t =>
     'Only HTTP(S) protocols are supported')))
 
 t.test('reject with error on network failure', t =>
-  t.rejects(fetch('http://localhost:50000/'), {
+  t.rejects(fetch('http://localhost:55555/'), {
     name: 'FetchError',
     code: 'ECONNREFUSED',
     errno: 'ECONNREFUSED',


### PR DESCRIPTION
i wrote a pretty long comment in the code to be sure that the error propagation never gets accidentally removed, and we remember to account for this situation when we eventually refactor this.

this resolves a lot of the `cb() never called` errors, especially those in Windows where i was able to reproduce the bug pretty easily. i suspect there's a similar issue in other operating systems, but was unable to prove it. similarly testing this proved somewhat difficult since the underlying request object is inaccessible from the response object the promise resolves to, so there isn't an easy way to manually trigger this problem.

this code is definitely due some refactoring, and as part of that it would be nice to allow access to the raw request and response objects so that we can test this accurately, but that work should not delay getting this fix released.