### PR TITLE
fix: Handle data: URIs more consistently

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -15,23 +15,41 @@ const { getNodeRequestOptions } = Request
 const FetchError = require('./fetch-error.js')
 const AbortError = require('./abort-error.js')
 
-const fetch = (url, opts) => {
+// XXX this should really be split up and unit-ized for easier testing
+// and better DRY implementation of data/http request aborting
+const fetch = async (url, opts) => {
   if (/^data:/.test(url)) {
     const request = new Request(url, opts)
-    try {
-      const split = url.split(',')
-      const data = Buffer.from(split[1], 'base64')
-      const type = split[0].match(/^data:(.*);base64$/)[1]
-      return Promise.resolve(new Response(data, {
-        headers: {
-          'Content-Type': type,
-          'Content-Length': data.length,
-        },
-      }))
-    } catch (er) {
-      return Promise.reject(new FetchError(`[${request.method}] ${
-        request.url} invalid URL, ${er.message}`, 'system', er))
-    }
+    // delay 1 promise tick so that the consumer can abort right away
+    return Promise.resolve().then(() => new Promise((resolve, reject) => {
+      let type, data
+      try {
+        const { pathname, search } = new URL(url)
+        const split = pathname.split(',')
+        if (split.length < 2) {
+          throw new Error('invalid data: URI')
+        }
+        const mime = split.shift()
+        const base64 = /;base64$/.test(mime)
+        type = base64 ? mime.slice(0, -1 * ';base64'.length) : mime
+        const rawData = decodeURIComponent(split.join(',') + search)
+        data = base64 ? Buffer.from(rawData, 'base64') : Buffer.from(rawData)
+      } catch (er) {
+        return reject(new FetchError(`[${request.method}] ${
+          request.url} invalid URL, ${er.message}`, 'system', er))
+      }
+
+      const { signal } = request
+      if (signal && signal.aborted) {
+        return reject(new AbortError('The user aborted a request.'))
+      }
+
+      const headers = { 'Content-Length': data.length }
+      if (type) {
+        headers['Content-Type'] = type
+      }
+      return resolve(new Response(data, { headers }))
+    }))
   }
 
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
1. No longer requires `;base64` to be included on `data:` URIs.
2. Supports immediately aborting `data:` URIs.

Fix: #18

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
