### PR TITLE
fix: compatibility with Electron

### DIFF
--- a/lib/body.js
+++ b/lib/body.js
@@ -1,6 +1,7 @@
 'use strict'
 const Minipass = require('minipass')
 const MinipassSized = require('minipass-sized')
+const { setTimeout } = require('timers')
 
 const Blob = require('./blob.js')
 const {BUFFER} = Blob


### PR DESCRIPTION
I met a problem in electron app

```
Uncaught (in promise) TypeError: r.unref is not a function
```

According to [this issue](https://github.com/electron/electron/issues/21162), we should require `setTimeout` from node.js library explicitly.
