### PR TITLE
feat: leverage request.setTimeout and the timeout event

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -70,10 +70,10 @@ const fetch = (url, opts) => {
     }
 
     const finalize = () => {
+      req.removeListener('timeout', onTimeout)
       req.abort()
       if (signal)
         signal.removeEventListener('abort', abortAndFinalize)
-      clearTimeout(reqTimeout)
     }
 
     // send request
@@ -82,15 +82,15 @@ const fetch = (url, opts) => {
     if (signal)
       signal.addEventListener('abort', abortAndFinalize)
 
-    let reqTimeout = null
+    const onTimeout = () => {
+      reject(new FetchError(`network timeout at: ${
+        request.url}`, 'request-timeout'))
+      finalize()
+    }
+    req.once('timeout', onTimeout)
+
     if (request.timeout) {
-      req.once('socket', socket => {
-        reqTimeout = setTimeout(() => {
-          reject(new FetchError(`network timeout at: ${
-            request.url}`, 'request-timeout'))
-          finalize()
-        }, request.timeout)
-      })
+      req.setTimeout(request.timeout)
     }
 
     req.on('error', er => {
@@ -113,8 +113,7 @@ const fetch = (url, opts) => {
     })
 
     req.on('response', res => {
-      clearTimeout(reqTimeout)
-
+      req.removeListener('timeout', onTimeout)
       const headers = createHeadersLenient(res.headers)
 
       // HTTP fetch step 5

--- a/test/fixtures/server.js
+++ b/test/fixtures/server.js
@@ -126,7 +126,7 @@ class TestServer {
     if (p === '/slow') {
       res.statusCode = 200
       res.setHeader('Content-Type', 'text/plain')
-      res.write('test')
+      res.flushHeaders()
       setTimeout(() => res.end('test'), 1000)
     }
 


### PR DESCRIPTION
there is a race condition between the original timeout handling here and
the socket's timeout event, which may fire if the user is passing in an
agent that has a timeout set. by using request.setTimeout and adding a
listener for the timeout event, we consolidate our timeout handling and
remove this race condition.

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
