### PR TITLE
fix: pass search params as part of path string

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -238,7 +238,7 @@ class Request extends Body {
         : '',
       host: parsedURL.host,
       hostname: parsedURL.hostname,
-      path: parsedURL.pathname,
+      path: `${parsedURL.pathname}${parsedURL.search}`,
       port: parsedURL.port,
       protocol: parsedURL.protocol,
     }

--- a/test/request.js
+++ b/test/request.js
@@ -398,6 +398,15 @@ t.test('get node request options', t => {
     family: 6,
   })
 
+  t.test('passes through search params', (t) => {
+    const req = new Request('http://x.y?one=two&three=four')
+    const options = Request.getNodeRequestOptions(req)
+    t.match(options, {
+      path: '/?one=two&three=four',
+    })
+    t.end()
+  })
+
   t.test('function as agent', t => {
     let agentCalled = false
     const agent = () => {


### PR DESCRIPTION
the previous refactor to use the `URL` constructor omitted the search parameters in the path property. due to missing test coverage, this was not identified. this corrects the problem and adds a test to prevent regression.
