### PR TITLE
fix: strip authorization and cookie headers on redirect to new host

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -204,6 +204,14 @@ const fetch = async (url, opts) => {
             timeout: request.timeout,
           }
 
+          // if the redirect is to a new hostname, strip the authorization and cookie headers
+          const parsedOriginal = new URL(request.url)
+          const parsedRedirect = new URL(locationURL)
+          if (parsedOriginal.hostname !== parsedRedirect.hostname) {
+            requestOpts.headers.delete('authorization')
+            requestOpts.headers.delete('cookie')
+          }
+
           // HTTP-redirect fetch step 11
           if (res.statusCode === 303 || (
             (res.statusCode === 301 || res.statusCode === 302) &&

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "abort-controller": "^3.0.0",
     "abortcontroller-polyfill": "~1.7.3",
     "form-data": "^4.0.0",
+    "nock": "^13.2.4",
     "parted": "^0.1.1",
     "string-to-arraybuffer": "^1.0.2",
     "tap": "^15.1.6"


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
we applied this same fix to `make-fetch-happen`, just carrying it through to here

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
