### PR TITLE
Expose AbortError

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -362,3 +362,4 @@ fetch.Headers = Headers
 fetch.Request = Request
 fetch.Response = Response
 fetch.FetchError = FetchError
+fetch.AbortError = AbortError

--- a/test/index.js
+++ b/test/index.js
@@ -4,7 +4,8 @@ const TestServer = require('./fixtures/server.js')
 const fetch = require('../lib/index.js')
 const stringToArrayBuffer = require('string-to-arraybuffer')
 const URLSearchParamsPolyfill = require('@ungap/url-search-params')
-const { FetchError, Headers, Request, Response } = fetch
+const { AbortError, FetchError, Headers, Request, Response } = fetch
+const AbortErrorOrig = require('../lib/abort-error.js')
 const FetchErrorOrig = require('../lib/fetch-error.js')
 const HeadersOrig = require('../lib/headers.js')
 const { createHeadersLenient } = HeadersOrig
@@ -80,7 +81,8 @@ t.test('return a promise', t => {
   t.end()
 })
 
-t.test('expose Headers, Response and Request constructors', t => {
+t.test('expose AbortError, FetchError, Headers, Response and Request constructors', t => {
+  t.equal(AbortError, AbortErrorOrig)
   t.equal(FetchError, FetchErrorOrig)
   t.equal(Headers, HeadersOrig)
   t.equal(Response, ResponseOrig)


### PR DESCRIPTION
Currently, if I pass in an `AbortSignal` and want to detect why the promise rejected, I have to write:

```js
import fetch from 'minipass-fetch'
import AbortError from 'minipass-fetch/lib/abort-error'
```

... in order to use the type:

```js
try {
  await fetch('https://example.com', { signal: AbortSignal.timeout(1000) })
} catch (err) {
  if (err instanceof AbortError) {
    // Timed out
  } else {
    // Something else went wrong
  }
}
```

This PR turns the preamble into:

```js
import fetch, { AbortError } from 'minipass-fetch'
```

... which is in line with how we're already exporting `FetchError`.

---

Playing devil's advocate:

* I _could_ also check `err.name`, `err.code`, or `err.type`, but none of those are guaranteed to originate from minipass-fetch. I'm not a fan of duck typing when it comes to errors.
* Other runtimes don't support this scenario either:
  * Node 17.7.2 (with `--experimental-fetch`) generates a vanilla `Error` with `code = 'ABORT_ERR'`.
  * Chrome generates a `DOMException`.
  * I didn't check Firefox, Safari, Deno, or Cloudflare Workers.