### PR TITLE
fix: do not setup the response timeout if the stream has already ended

### DIFF
--- a/lib/body.js
+++ b/lib/body.js
@@ -127,8 +127,10 @@ class Body {
       : this.size ? new MinipassSized({ size: this.size })
       : new Minipass()
 
-    // allow timeout on slow response body
-    const resTimeout = this.timeout ? setTimeout(() => {
+    // allow timeout on slow response body, but only if the stream is still writable. this
+    // makes the timeout center on the socket stream from lib/index.js rather than the
+    // intermediary minipass stream we create to receive the data
+    const resTimeout = this.timeout && stream.writable ? setTimeout(() => {
       stream.emit('error', new FetchError(
         `Response timeout while trying to fetch ${
           this.url} (over ${this.timeout}ms)`, 'body-timeout'))


### PR DESCRIPTION
this change ensures we will not trigger a timeout caused by a slow
stream pipeline if the stream has already ended. this subtly shifts the
meaning of the timeout from "the response has been fully consumed" to
"the socket behind the response has finished" which i feel maintains the
spirit of the timeout while also not needlessly throwing errors when
we're not using the socket any more.

fixes npm/cli#3078
