### PR TITLE
fix: TypeError crashes program in case of invalid url in redirect

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -144,18 +144,18 @@ const fetch = async (url, opts) => {
 
         // HTTP fetch step 5.3
         let locationURL = null;
- 				try {
- 					locationURL = location === null ? null : new URL(location, request.url).toString();
- 				} catch {
- 					// error here can only be invalid URL in Location: header
- 					// do not throw when options.redirect == manual
- 					// let the user extract the errorneous redirect URL
- 					if (request.redirect !== 'manual') {
- 						reject(new FetchError(`uri requested responds with an invalid redirect URL: ${location}`, 'invalid-redirect'));
- 						finalize();
- 						return;
- 					}
- 				}
+        try {
+          locationURL = location === null ? null : new URL(location, request.url).toString();
+        } catch {
+          // error here can only be invalid URL in Location: header
+          // do not throw when options.redirect == manual
+          // let the user extract the errorneous redirect URL
+          if (request.redirect !== 'manual') {
+            reject(new FetchError(`uri requested responds with an invalid redirect URL: ${location}`, 'invalid-redirect'));
+            finalize();
+            return;
+          }
+        }
 
         // HTTP fetch step 5.5
         if (request.redirect === 'error') {

--- a/lib/index.js
+++ b/lib/index.js
@@ -143,8 +143,19 @@ const fetch = async (url, opts) => {
         const location = headers.get('Location')
 
         // HTTP fetch step 5.3
-        const locationURL = location === null ? null
-          : (new URL(location, request.url)).toString()
+        let locationURL = null;
+ 				try {
+ 					locationURL = location === null ? null : new URL(location, request.url).toString();
+ 				} catch {
+ 					// error here can only be invalid URL in Location: header
+ 					// do not throw when options.redirect == manual
+ 					// let the user extract the errorneous redirect URL
+ 					if (request.redirect !== 'manual') {
+ 						reject(new FetchError(`uri requested responds with an invalid redirect URL: ${location}`, 'invalid-redirect'));
+ 						finalize();
+ 						return;
+ 					}
+ 				}
 
         // HTTP fetch step 5.5
         if (request.redirect === 'error') {

--- a/test/fixtures/server.js
+++ b/test/fixtures/server.js
@@ -223,6 +223,12 @@ class TestServer {
       res.end()
     }
 
+    if (p === '/redirect/301/invalid') {
+      res.statusCode = 301;
+      res.setHeader('Location', '//super:invalid:url%/');
+      res.end();
+    }
+
     if (p === '/redirect/302') {
       res.statusCode = 302
       res.setHeader('Location', '/inspect')

--- a/test/index.js
+++ b/test/index.js
@@ -379,6 +379,29 @@ t.test('treat broken redirect as ordinary response (manual)', t => {
   })
 })
 
+t.test('should process an invalid redirect (manual)', t => {
+  const url = `${base}redirect/301/invalid`
+  const options = {
+    redirect: 'manual',
+  }
+  return fetch(url, options).then(res => {
+    t.equal(res.url, url)
+    t.equal(res.status, 301)
+    t.equal(res.headers.get('location'), '//super:invalid:url%/')
+  })
+})
+
+t.test('should throw an error on invalid redirect url', t => {
+  const url = `${base}redirect/301/invalid`
+  return fetch(url).then(res => {
+    t.fail()
+  }).catch((err) => {
+    t.type(err, FetchError)
+    t.equal(err.message, 'uri requested responds with an invalid redirect URL: //super:invalid:url%/')
+  })
+})
+
+
 t.test('set redirected property on response when redirect', t =>
   fetch(`${base}redirect/301`).then(res => t.equal(res.redirected, true)))
 


### PR DESCRIPTION
## Description

Calling `fetch()` on a server that responds with an invalid URL breaks the execution of the program with the following unhandled error:
```python
internal/url.js:259
  throw new ERR_INVALID_URL(input);
  ^

TypeError [ERR_INVALID_URL]: Invalid URL: :some:weird%invalid%url%
```

## Steps to reproduce:

1. To simulate the environment that the bug appears in, set up a local server redirecting to an invalid URL

```js
const http = require('http');
const server = http.createServer((req, res, next) => {
	res.writeHead(301, {'Location' : 'http://www.stackoverflow.com%'});
	res.end();
});
server.listen(process.env.PORT || 3000);
```

2. Then running this code throws error and crashes the program despite `fetch()` being wrapped in a try/catch block.

```js
let fetch = require('minipass-fetch')

(async function {
	try{
		var res = await fetch(
			'http://localhost:3000',
		//	{redirect: 'manual'}
		)
		console.log('val: ', res)
	} catch (err) {
		console.log('err: ', err)
	}
})()
```

## References
This behavior is inconsistent with current node-fetch. Similar issue reported [#1386](https://github.com/node-fetch/node-fetch/issues/1386) and fixed [#1387](https://github.com/node-fetch/node-fetch/pull/1387) in node-fetch.

