### PR TITLE
fix: Support longer timeouts - Inform http/tls timeout of chosen timeout

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -265,6 +265,7 @@ class Request extends Body {
       secureProtocol,
       servername,
       sessionIdContext,
+      timeout: request.timeout,
     }
   }
 }


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
Since the underlying connection has no knowledge of the timeout set, shorter timeouts are handled by the custom `setTimeout`, but since the underlying connection has it's own internal timeout, it can fail and error out if it's timeout is not greater than that of the internal error handling.

In this implementation, I only set it to be equal; but if you'd prefer to always have the internal error handling for timeouts run first, I realize now maybe I could increase the native timeout to something greater than what's provided.

### Example of issue
```js
const timeout = 100000000
await fetch('someSlowUrl',{timeout})

// At exactly 60000ms
/*
FetchError: request to https://registry.npmjs.org... failed, reason: connect ETIMEDOUT npmIp:443
at ClientRequest.<anonymous> (C:\Users\name\AppData\Roaming\npm\node_modules\npm-check-updates\node_modules\minipass-fetch\lib\index.js:97:14)
    at ClientRequest.emit (node:events:394:28)
    at TLSSocket.socketErrorListener (node:_http_client:447:9)
    at TLSSocket.emit (node:events:406:35)
    at emitErrorNT (node:internal/streams/destroy:193:8)
    at emitErrorCloseNT (node:internal/streams/destroy:158:3)
    at processTicksAndRejections (node:internal/process/task_queues:83:21) {
  code: 'ETIMEDOUT',
  errno: 'ETIMEDOUT',
  syscall: 'connect',
  address: '104.16.25.35',
  port: 443,
  type: 'system'
}
*/

```

Looked at trying to make a test for this, but couldn't think of a way to test without making a test that runs longer than a minute. Can't find any testing docs explaining any way to shim/mock or change node internal defaults.

## References
Fixes #16

