### PR TITLE
feat: respect NODE_TLS_REJECT_UNAUTHORIZED

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -94,12 +94,9 @@ const fetch = async (url, opts) => {
       clearTimeout(reqTimeout)
     }
 
-    if (process.env['NODE_TLS_REJECT_UNAUTHORIZED'] == '0') {
-        console.warn("-----------------------[ minipass-fetch ]-----------------------------");
-        console.warn("- NODE_TLS_REJECT_UNAUTHORIZED is set to 0. This is not recommended. -");
-        console.warn("----------------------------------------------------------------------");
-
-        options.agent.options.rejectUnauthorized = false;
+    if (process.env['NODE_TLS_REJECT_UNAUTHORIZED'] === '0') {
+      options.agent = options.agent || new https.Agent()
+      options.agent.options.rejectUnauthorized = false
     }
 
     // send request

--- a/lib/index.js
+++ b/lib/index.js
@@ -94,6 +94,14 @@ const fetch = async (url, opts) => {
       clearTimeout(reqTimeout)
     }
 
+    if (process.env['NODE_TLS_REJECT_UNAUTHORIZED'] == '0') {
+        console.warn("-----------------------[ minipass-fetch ]-----------------------------");
+        console.warn("- NODE_TLS_REJECT_UNAUTHORIZED is set to 0. This is not recommended. -");
+        console.warn("----------------------------------------------------------------------");
+
+        options.agent.options.rejectUnauthorized = false;
+    }
+
     // send request
     const req = send(options)
 

--- a/test/https-with-ca-option.js
+++ b/test/https-with-ca-option.js
@@ -19,37 +19,37 @@ const ca = read(`${fixtures}/minipass-CA.pem`)
 
 let server = null
 t.before(() => new Promise((res) => {
-    server = createServer({
-        cert: read(`${fixtures}/localhost.crt`),
-        key: read(`${fixtures}/localhost.key`),
-    }, (q, s) => {
-        s.setHeader('content-type', 'text/plain')
-        s.setHeader('connection', 'close')
-        s.end(`${q.method} ${q.url}`)
-    }).listen(port, res)
+  server = createServer({
+    cert: read(`${fixtures}/localhost.crt`),
+    key: read(`${fixtures}/localhost.key`),
+  }, (q, s) => {
+    s.setHeader('content-type', 'text/plain')
+    s.setHeader('connection', 'close')
+    s.end(`${q.method} ${q.url}`)
+  }).listen(port, res)
 }))
 t.teardown(() => server.close())
 
 // this test will fail after Jan 30 23:23:26 2025 GMT
 t.test('make https request without ca, should fail', t =>
-    t.rejects(fetch(`${base}hello`), {
-        name: 'FetchError',
-        message: `request to ${base}hello failed, reason: unable to verify the first certificate`,
-        code: 'UNABLE_TO_VERIFY_LEAF_SIGNATURE',
-        errno: 'UNABLE_TO_VERIFY_LEAF_SIGNATURE',
-        type: 'system',
-    }))
+  t.rejects(fetch(`${base}hello`), {
+    name: 'FetchError',
+    message: `request to ${base}hello failed, reason: unable to verify the first certificate`,
+    code: 'UNABLE_TO_VERIFY_LEAF_SIGNATURE',
+    errno: 'UNABLE_TO_VERIFY_LEAF_SIGNATURE',
+    type: 'system',
+  }))
 
 t.test('make https request with rejectUnauthorized:false, succeeds', async t =>
-    t.equal(await (await fetch(`${base}hello`, { rejectUnauthorized: false })).text(),
-        'GET /hello'))
+  t.equal(await (await fetch(`${base}hello`, { rejectUnauthorized: false })).text(),
+    'GET /hello'))
 
 t.test("make https request with process.env['NODE_TLS_REJECT_UNAUTHORIZED'] = '0', succeeds", async t => {
-    process.env['NODE_TLS_REJECT_UNAUTHORIZED'] = '0'
-    t.equal(await (await fetch(`${base}hello`)).text(), 'GET /hello')
-    process.env['NODE_TLS_REJECT_UNAUTHORIZED'] = undefined
+  process.env['NODE_TLS_REJECT_UNAUTHORIZED'] = '0'
+  t.equal(await (await fetch(`${base}hello`)).text(), 'GET /hello')
+  process.env['NODE_TLS_REJECT_UNAUTHORIZED'] = undefined
 })
 
 t.test('make https request with ca, succeeds', async t =>
-    t.equal(await (await fetch(`${base}hello`, { ca })).text(),
-        'GET /hello'))
+  t.equal(await (await fetch(`${base}hello`, { ca })).text(),
+    'GET /hello'))


### PR DESCRIPTION
As described in #61, setting the NODE_TLS_REJECT_UNAUTHORIZED environment variable doesn't change the library's behavior. This is required in different scenarios, such as testing, self-signed certificates, ZScaler, etc.

This PR adds a check for the process's environment variable NODE_TLS_REJECT_UNAUTHORIZED, and if it is set to `0` sets `rejectUnauthorized` to `false`.

```
if (process.env['NODE_TLS_REJECT_UNAUTHORIZED'] == '0') {
  console.warn("-----------------------[ minipass-fetch ]-----------------------------");
  console.warn("- NODE_TLS_REJECT_UNAUTHORIZED is set to 0. This is not recommended. -");
  console.warn("----------------------------------------------------------------------");

  options.agent.options.rejectUnauthorized = false;
}
```

## References
  Fixes #61
  Closes #61 
