### PR TITLE
fix: avoid deadlock in deflate-encoded responses

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -318,8 +318,7 @@ const fetch = async (url, opts) => {
       if (codings === 'deflate' || codings === 'x-deflate') {
         // handle the infamous raw deflate response from old servers
         // a hack for old IIS and Apache servers
-        const raw = res.pipe(new Minipass({ async: true }))
-        raw.once('data', chunk => {
+        res.once('data', chunk => {
           // see http://stackoverflow.com/questions/37519828
           const decoder = (chunk[0] & 0x0F) === 0x08
             ? new zlib.Inflate()

--- a/lib/index.js
+++ b/lib/index.js
@@ -318,7 +318,7 @@ const fetch = async (url, opts) => {
       if (codings === 'deflate' || codings === 'x-deflate') {
         // handle the infamous raw deflate response from old servers
         // a hack for old IIS and Apache servers
-        const raw = res.pipe(new Minipass())
+        const raw = res.pipe(new Minipass({ async: true }))
         raw.once('data', chunk => {
           // see http://stackoverflow.com/questions/37519828
           const decoder = (chunk[0] & 0x0F) === 0x08

--- a/test/decompress-async.js
+++ b/test/decompress-async.js
@@ -1,0 +1,76 @@
+'use strict'
+const t = require('tap')
+const fetch = require('../lib/index.js')
+const realZlib = require('zlib')
+const nock = require('nock')
+
+// We additionally test decompression here using nock as it seems to recreate a
+// hard to diagnose condition: https://github.com/npm/minipass-fetch/issues/166
+// If you see `test unfinished` this file has done its job and you need to find
+// why the stream died early. The above ticket has details.
+
+t.test('decompress response when using async pipe', async t => {
+  t.test('using gzip', async t => {
+    const input = 'hello world'
+    const gzipd = realZlib.gzipSync(Buffer.from(input, 'utf8'))
+    nock('http://a.b', { allowUnmocked: false })
+      .get('/gzip')
+      .reply(200, gzipd, {
+        'Content-Type': 'text/plain',
+        'Content-Encoding': 'gzip',
+      })
+
+    const res = await fetch('http://a.b/gzip')
+    const result = await res.text()
+    t.equal(result, input, 'gzip response processed correctly when using async pipe')
+    t.end()
+  })
+
+  t.test('using deflate', async t => {
+    const input = 'hello world'
+    const deflated = realZlib.deflateSync(Buffer.from(input, 'utf8'))
+    nock('http://a.b', { allowUnmocked: false })
+      .get('/deflate')
+      .reply(200, deflated, {
+        'Content-Type': 'text/plain',
+        'Content-Encoding': 'deflate',
+      })
+
+    const res = await fetch('http://a.b/deflate')
+    const result = await res.text()
+    t.equal(result, input, 'deflate response processed correctly when using async pipe')
+    t.end()
+  })
+
+  t.test('using deflate raw', async t => {
+    const input = 'hello world'
+    const deflated = realZlib.deflateRawSync(Buffer.from(input, 'utf8'))
+    nock('http://a.b', { allowUnmocked: false })
+      .get('/deflate')
+      .reply(200, deflated, {
+        'Content-Type': 'text/plain',
+        'Content-Encoding': 'deflate',
+      })
+
+    const res = await fetch('http://a.b/deflate')
+    const result = await res.text()
+    t.equal(result, input, 'deflate raw response processed correctly when using async pipe')
+    t.end()
+  })
+
+  t.test('using brotli', async t => {
+    const input = 'hello world'
+    const brotlid = realZlib.brotliCompressSync(Buffer.from(input, 'utf8'))
+    nock('http://a.b', { allowUnmocked: false })
+      .get('/brotli')
+      .reply(200, brotlid, {
+        'Content-Type': 'text/plain',
+        'Content-Encoding': 'br',
+      })
+
+    const res = await fetch('http://a.b/brotli')
+    const result = await res.text()
+    t.equal(result, input, 'brotli response processed correctly when using async pipe')
+    t.end()
+  })
+})


### PR DESCRIPTION
<!-- What / Why -->
Requests that return deflate encoded bodies seemingly disappear. I'd really like to understand why this is happening better but I suspect the bit in [minipass's README warning about `end` event behaviors](https://github.com/isaacs/minipass/blob/main/README.md#immediately-emit-end-for-empty-streams-when-not-paused) is related.

<!-- Describe the request in detail. What it does and why it's being changed. -->
A small reproducible example from the the original ticket:
```javascript
const fetch = require('minipass-fetch')

const url = 'https://marine-api.open-meteo.com/v1/marine?latitude=39.0&longitude=9.75&hourly=swell_wave_height,swell_wave_direction,swell_wave_period&models=best_match&timezone=Europe%2FBerlin'

Promise.resolve().then(async () => {
  console.log('fetching')
  const b = await fetch(url)

  console.log('response:', b)
  console.log(await b.json())
})
```

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
Fixes #166 
