### PR TITLE
move from encoding to iconv-lite

### DIFF
--- a/lib/body.js
+++ b/lib/body.js
@@ -6,10 +6,10 @@ const Blob = require('./blob.js')
 const { BUFFER } = Blob
 const FetchError = require('./fetch-error.js')
 
-// optional dependency on 'encoding'
-let convert
+// optional dependency on 'iconv-lite'
+let decode
 try {
-  convert = require('encoding').convert
+  decode = require('iconv-lite').decode
 } catch (e) {
   // defer error until textConverted is called
 }
@@ -92,6 +92,10 @@ class Body {
   }
 
   textConverted () {
+    /* istanbul ignore if */
+    if (typeof decode !== 'function') {
+      throw new Error('The package `iconv-lite` must be installed to use the textConverted() function')
+    }
     return this[CONSUME_BODY]().then(buf => convertBody(buf, this.headers))
   }
 
@@ -285,11 +289,6 @@ const isBlob = obj =>
   /^(Blob|File)$/.test(obj[Symbol.toStringTag])
 
 const convertBody = (buffer, headers) => {
-  /* istanbul ignore if */
-  if (typeof convert !== 'function') {
-    throw new Error('The package `encoding` must be installed to use the textConverted() function')
-  }
-
   const ct = headers && headers.get('content-type')
   let charset = 'utf-8'
   let res
@@ -339,12 +338,23 @@ const convertBody = (buffer, headers) => {
     }
   }
 
-  // turn raw buffers into a single utf-8 buffer
-  return convert(
-    buffer,
-    'UTF-8',
-    charset
-  ).toString()
+  if (charset === 'UTF-8') {
+    return buffer.toString('UTF-8')
+  }
+
+  charset = charset.toString().trim()
+    .replace(/^latin[-_]?(\d+)$/i, 'ISO-8859-$1')
+    .replace(/^win(?:dows)?[-_]?(\d+)$/i, 'WINDOWS-$1')
+    .replace(/^utf[-_]?(\d+)$/i, 'UTF-$1')
+    .replace(/^ks_c_5601-1987$/i, 'CP949')
+    .replace(/^us[-_]?ascii$/i, 'ASCII')
+    .toUpperCase()
+  try {
+    return decode(buffer, charset).toString()
+  } catch {
+    /* istanbul ignore next */
+    return buffer.toString('UTF-8')
+  }
 }
 
 module.exports = Body

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "abort-controller": "^3.0.0",
     "abortcontroller-polyfill": "~1.7.3",
     "form-data": "^4.0.0",
+    "iconv-lite": "^0.7.2",
     "nock": "^13.2.4",
     "parted": "^0.1.1",
     "string-to-arraybuffer": "^1.0.2",
@@ -39,6 +40,9 @@
     "minipass": "^7.0.3",
     "minipass-sized": "^2.0.0",
     "minizlib": "^3.0.1"
+  },
+  "optionalDependencies": {
+    "iconv-lite": "^0.7.2"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "@ungap/url-search-params": "^0.2.2",
     "abort-controller": "^3.0.0",
     "abortcontroller-polyfill": "~1.7.3",
-    "encoding": "^0.1.13",
     "form-data": "^4.0.0",
     "nock": "^13.2.4",
     "parted": "^0.1.1",
@@ -40,9 +39,6 @@
     "minipass": "^7.0.3",
     "minipass-sized": "^2.0.0",
     "minizlib": "^3.0.1"
-  },
-  "optionalDependencies": {
-    "encoding": "^0.1.13"
   },
   "repository": {
     "type": "git",

--- a/test/body.js
+++ b/test/body.js
@@ -10,6 +10,7 @@ const { Minipass } = require('minipass')
 const { MinipassSized } = require('minipass-sized')
 const AbortError = require('../lib/abort-error.js')
 const { PassThrough } = require('stream')
+const iconvLite = require('iconv-lite')
 
 t.test('null body', async t => {
   const b = new Body()
@@ -351,11 +352,9 @@ t.test('clone', t => {
 })
 
 t.test('convert body', t => {
-  const { convert } = require('encoding')
-
   t.test('content-type header', async t => {
     const s = '中文'
-    const b = new Body(convert(s, 'gbk'))
+    const b = new Body(iconvLite.encode(s, 'gbk'))
     b.headers = { get () {
       return 'text/plain; charset=gbk; qs=1'
     } }
@@ -364,37 +363,37 @@ t.test('convert body', t => {
 
   t.test('html4 meta tag', async t => {
     const s = '<meta http-equiv="Content-Type" content="text/html; charset=gbk"><div>中文L</div>'
-    const b = new Body(convert(s, 'gbk'))
+    const b = new Body(iconvLite.encode(s, 'gbk'))
     t.equal(await b.textConverted(), s)
   })
 
   t.test('html4 meta tag reversed', async t => {
     const s = '<meta content="text/html; charset=gbk" http-equiv="Content-Type"><div>中文L</div>'
-    const b = new Body(convert(s, 'gbk'))
+    const b = new Body(iconvLite.encode(s, 'gbk'))
     t.equal(await b.textConverted(), s)
   })
 
   t.test('html5 meta tag', async t => {
     const s = '<meta charset="gbk"><div>中文</div>'
-    const b = new Body(convert(s, 'gbk'))
+    const b = new Body(iconvLite.encode(s, 'gbk'))
     t.equal(await b.textConverted(), s)
   })
 
   t.test('xml encoding', async t => {
     const s = '<?xml encoding="gbk"?><div>中文</div>'
-    const b = new Body(convert(s, 'gbk'))
+    const b = new Body(iconvLite.encode(s, 'gbk'))
     t.equal(await b.textConverted(), s)
   })
 
   t.test('explicitly utf8', async t => {
     const s = '<?xml encoding="UTF-8"?><div>中文</div>'
-    const b = new Body(s)
+    const b = new Body(Buffer.from(s, 'UTF-8'))
     t.equal(await b.textConverted(), s)
   })
 
   t.test('no encoding set', async t => {
     const s = '中文'
-    const b = new Body(s)
+    const b = new Body(Buffer.from(s, 'UTF-8'))
     t.equal(await b.textConverted(), s)
   })
 

--- a/test/fixtures/server.js
+++ b/test/fixtures/server.js
@@ -1,7 +1,7 @@
 const http = require('http')
 const zlib = require('minizlib')
 const { multipart: Multipart } = require('parted')
-const convert = require('encoding').convert
+const iconvLite = require('iconv-lite')
 
 class TestServer {
   constructor () {
@@ -154,33 +154,33 @@ class TestServer {
     if (p === '/encoding/gbk') {
       res.statusCode = 200
       res.setHeader('Content-Type', 'text/html')
-      res.end(convert('<meta charset="gbk"><div>中文</div>', 'gbk'))
+      res.end(iconvLite.encode('<meta charset="gbk"><div>中文</div>', 'gbk'))
     }
 
     if (p === '/encoding/gb2312') {
       res.statusCode = 200
       res.setHeader('Content-Type', 'text/html')
-      res.end(convert('<meta http-equiv="Content-Type" content="text/html; charset=gb2312">' +
+      res.end(iconvLite.encode('<meta http-equiv="Content-Type" content="text/html; charset=gb2312">' +
         '<div>中文</div>', 'gb2312'))
     }
 
     if (p === '/encoding/gb2312-reverse') {
       res.statusCode = 200
       res.setHeader('Content-Type', 'text/html')
-      res.end(convert('<meta content="text/html; charset=gb2312" http-equiv="Content-Type">' +
+      res.end(iconvLite.encode('<meta content="text/html; charset=gb2312" http-equiv="Content-Type">' +
         '<div>中文</div>', 'gb2312'))
     }
 
     if (p === '/encoding/shift-jis') {
       res.statusCode = 200
       res.setHeader('Content-Type', 'text/html; charset=Shift-JIS')
-      res.end(convert('<div>日本語</div>', 'Shift_JIS'))
+      res.end(iconvLite.encode('<div>日本語</div>', 'Shift_JIS'))
     }
 
     if (p === '/encoding/euc-jp') {
       res.statusCode = 200
       res.setHeader('Content-Type', 'text/xml')
-      res.end(convert('<?xml version="1.0" encoding="EUC-JP"?><title>日本語</title>', 'EUC-JP'))
+      res.end(iconvLite.encode('<?xml version="1.0" encoding="EUC-JP"?><title>日本語</title>', 'EUC-JP'))
     }
 
     if (p === '/encoding/utf8') {
@@ -191,13 +191,13 @@ class TestServer {
     if (p === '/encoding/order1') {
       res.statusCode = 200
       res.setHeader('Content-Type', 'charset=gbk; text/plain')
-      res.end(convert('中文', 'gbk'))
+      res.end(iconvLite.encode('中文', 'gbk'))
     }
 
     if (p === '/encoding/order2') {
       res.statusCode = 200
       res.setHeader('Content-Type', 'text/plain; charset=gbk; qs=1')
-      res.end(convert('中文', 'gbk'))
+      res.end(iconvLite.encode('中文', 'gbk'))
     }
 
     if (p === '/encoding/chunked') {
@@ -205,7 +205,7 @@ class TestServer {
       res.setHeader('Content-Type', 'text/html')
       res.setHeader('Transfer-Encoding', 'chunked')
       res.write('a'.repeat(10))
-      res.end(convert('<meta http-equiv="Content-Type" content="text/html; charset=Shift_JIS" />' +
+      res.end(iconvLite.encode('<meta http-equiv="Content-Type" content="text/html; charset=Shift_JIS" />' +
         '<div>日本語</div>', 'Shift_JIS'))
     }
 
@@ -214,7 +214,7 @@ class TestServer {
       res.setHeader('Content-Type', 'text/html')
       res.setHeader('Transfer-Encoding', 'chunked')
       res.write('a'.repeat(1200))
-      res.end(convert('中文', 'gbk'))
+      res.end(iconvLite.encode('中文', 'gbk'))
     }
 
     if (p === '/redirect/301') {


### PR DESCRIPTION
Most of what encoding was doing was either for tests or a passthrough to iconv-lite.

All of the actual code paths used were inlined into `lib/body.js`, and the tests were also adapted to encode their content directly using iconv-lite.

Ref: https://github.com/npm/statusboard/issues/1065