### PR TITLE
fix: strip proxy-authorization header on cross-host redirect

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -216,12 +216,14 @@ const fetch = async (url, opts) => {
             timeout: request.timeout,
           }
 
-          // if the redirect is to a new hostname, strip the authorization and cookie headers
+          // if the redirect is to a new hostname, strip the authorization,
+          // cookie, and proxy-authorization headers
           const parsedOriginal = new URL(request.url)
           const parsedRedirect = new URL(locationURL)
           if (parsedOriginal.hostname !== parsedRedirect.hostname) {
             requestOpts.headers.delete('authorization')
             requestOpts.headers.delete('cookie')
+            requestOpts.headers.delete('proxy-authorization')
           }
 
           // HTTP-redirect fetch step 11

--- a/test/index.js
+++ b/test/index.js
@@ -206,13 +206,14 @@ t.test('redirect to different host strips headers', async (t) => {
     reqheaders: {
       authorization: 'totally-authed-request',
       cookie: 'fake-cookie',
+      'proxy-authorization': 'fake-proxy-auth',
     },
   })
     .get('/')
     .reply(301, null, { location: 'http://a.b' })
 
   const second = nock('http://a.b', {
-    badheaders: ['authorization', 'cookie'],
+    badheaders: ['authorization', 'cookie', 'proxy-authorization'],
   })
     .get('/')
     .reply(200)
@@ -221,6 +222,7 @@ t.test('redirect to different host strips headers', async (t) => {
     headers: {
       authorization: 'totally-authed-request',
       cookie: 'fake-cookie',
+      'proxy-authorization': 'fake-proxy-auth',
     },
   })
   await res.text() // drain the response stream


### PR DESCRIPTION
When a request is redirected to a different hostname, minipass-fetch already drops the `authorization` and `cookie` headers so credentials are not forwarded to the new host (added in #45). The `proxy-authorization` header is a credential header in the same class, but it is not dropped, so it stays on the redirected request and reaches the new host.

This adds `proxy-authorization` to that same strip, right next to `authorization` and `cookie`. The redirect condition and everything else are unchanged.

The other redirect-following clients already treat `proxy-authorization` as part of this boundary:

- undici removes `authorization`, `cookie`, and `proxy-authorization` on a cross-origin redirect.
- follow-redirects drops `Authorization`, `Proxy-Authorization`, and `Cookie` across host/scheme changes (it added `Proxy-Authorization` for CVE-2024-28849).
- `@microsoft/kiota-http-fetchlibrary` added `Proxy-Authorization` to its cross-origin scrub recently (CVE-2026-49336).

Scope: this is the same threat model as the existing `authorization`/`cookie` strip, that is, a caller that sets a `Proxy-Authorization` header and then follows a redirect to a different host. It is defence in depth for parity with the clients above, not a new class of exploit.

The existing "redirect to different host strips headers" test now also sends a `proxy-authorization` header and asserts it is absent on the redirected request. Without the change the test fails, because the header reaches the new host.
